### PR TITLE
Disallow adding multiple coaches to one team

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -12,7 +12,7 @@ class Team(models.Model):
 class Coach(models.Model):
     name = models.CharField(max_length=100, blank=False, null=False)
     date_of_birth = models.DateField(blank=True, null=True)
-    current_team = models.ForeignKey('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
+    current_team = models.OneToOneField('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Change current_team field in Coach Model to OneToOneField to prevent adding mutliple coaches to one team. Resolves #17.