### PR TITLE
List only key Player and Coach info in Team List

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -18,9 +18,34 @@ class PlayerSerializer(serializers.HyperlinkedModelSerializer):
             'three_point_field_goal_percentage', 'free_throw_percentage'
         ]
 
+
 class TeamSerializer(serializers.HyperlinkedModelSerializer):
-    players = PlayerSerializer(many=True, read_only=True)
+    players = serializers.SerializerMethodField()
+    coach = serializers.SerializerMethodField()
 
     class Meta:
         model = Team
-        fields = ['url', 'id', 'name_abbreviation', 'full_name', 'players']
+        fields = ['url', 'id', 'name_abbreviation', 'full_name', 'coach', 'players']
+
+    def get_coach(self, obj):
+        coach_instance = obj.coach
+        coach_data = CoachSerializer(coach_instance, context=self.context).data
+        return {
+            'url': coach_data.get('url', None),
+            'id': coach_data.get('id', None),
+            'name': coach_data.get('name', None),
+        }
+
+    def get_players(self, obj):
+        players_queryset = obj.players.all()
+        players_data = PlayerSerializer(players_queryset, many=True, context=self.context).data
+
+        return [
+            {
+                'url': player_data.get('url', None),
+                'id': player_data.get('id', None),
+                'name': player_data.get('name', None),
+                'position': player_data.get('position', None)
+            }
+            for player_data in players_data
+        ]


### PR DESCRIPTION
Improve serializers to not list all parameters about the players and coaches of each team. All info is still shown in specific urls. Resolves #21