### PR TITLE
Create serializer, viewset and urls for Game Model

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -8,10 +8,12 @@ router = DefaultRouter()
 router.register(r'teams', views.TeamViewSet, basename='team')
 router.register(r'coaches', views.CoachViewSet, basename='coach')
 router.register(r'players', views.PlayerViewSet, basename='player')
+router.register(r'games', views.GameViewSet, basename='game')
 
 teams_router = routers.NestedSimpleRouter(router, r'teams', lookup='team')
 teams_router.register(r'coach', views.CoachViewSet, basename='team-coach')
 teams_router.register(r'players', views.PlayerViewSet, basename='team-player')
+teams_router.register(r'games', views.GameViewSet, basename='team-game')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,5 @@
-from api.models import Team, Coach, Player
-from api.serializers import TeamSerializer, CoachSerializer, PlayerSerializer
+from api.models import Team, Coach, Player, Game
+from api.serializers import TeamSerializer, CoachSerializer, PlayerSerializer, GameSerializer
 from rest_framework import viewsets
 from rest_framework import permissions
 
@@ -34,3 +34,17 @@ class PlayerViewSet(viewsets.ModelViewSet):
             return Player.objects.filter(team_id=team_id)
         else:
             return Player.objects.all()
+
+
+class GameViewSet(viewsets.ModelViewSet):
+    queryset = Game.objects.all()
+    serializer_class = GameSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        team_id = self.kwargs.get('team_pk')
+        if team_id:
+            team_games = Game.objects.filter(away_team_id=team_id) | Game.objects.filter(home_team_id=team_id)
+            return team_games
+        else:
+            return Game.objects.all()


### PR DESCRIPTION
Create a serializer class for Game model and expand TeamSerializer so it lists all games of each team. Create a Game viewset which filters specific team's games and route basic and nested Game urls. Resolves #36.