### PR TITLE
Remove "current" from coaches' team related fields

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -12,7 +12,7 @@ class Team(models.Model):
 class Coach(models.Model):
     name = models.CharField(max_length=100, blank=False, null=False)
     date_of_birth = models.DateField(blank=True, null=True)
-    current_team = models.OneToOneField('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
+    team = models.OneToOneField('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
 
     def __str__(self):
         return self.name

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -9,11 +9,11 @@ from api.validators import (
 
 
 class CoachSerializer(serializers.HyperlinkedModelSerializer):
-    current_team_name_abbreviation = serializers.ReadOnlyField(source='current_team.name_abbreviation')
+    team_name_abbreviation = serializers.ReadOnlyField(source='team.name_abbreviation')
 
     class Meta:
         model = Coach
-        fields = ['url', 'id', 'name', 'date_of_birth', 'current_team', 'current_team_name_abbreviation']
+        fields = ['url', 'id', 'name', 'date_of_birth', 'team', 'team_name_abbreviation']
 
     def validate_name(self, value):
         return validate_alpha_and_title(value, 'Name should only contain letters.', 'Name should be capitalized.')

--- a/api/views.py
+++ b/api/views.py
@@ -18,7 +18,7 @@ class CoachViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         team_id = self.kwargs.get('team_pk')
         if team_id:
-            return Coach.objects.filter(current_team_id=team_id)
+            return Coach.objects.filter(team_id=team_id)
         else:
             return Coach.objects.all()
 


### PR DESCRIPTION
Keep only "team" instead of "current_team" in coaches' team related fields to improve readibility