### PR TITLE
Add stats and expand other serializers

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -58,3 +58,23 @@ class Game(models.Model):
 
     def __str__(self):
         return f"{self.away_team} @ {self.home_team} - {self.date}"
+
+
+class Stats(models.Model):
+    game = models.ForeignKey('Game', related_name='stats', on_delete=models.CASCADE)
+    player = models.ForeignKey('Player', related_name='stats', on_delete=models.CASCADE)
+    field_goals_made = models.IntegerField(null=False, blank=False)
+    field_goals_attempted = models.IntegerField(null=False, blank=False)
+    three_pointers_made = models.IntegerField(null=False, blank=False)
+    three_pointers_attempted = models.IntegerField(null=False, blank=False)
+    free_throws_made = models.IntegerField(null=False, blank=False)
+    free_throws_attempted = models.IntegerField(null=False, blank=False)
+    defensive_rebounds = models.IntegerField(null=False, blank=False)
+    offensive_rebounds = models.IntegerField(null=False, blank=False)
+    assists = models.IntegerField(null=False, blank=False)
+    steals = models.IntegerField(null=False, blank=False)
+    blocks = models.IntegerField(null=False, blank=False)
+    turnovers = models.IntegerField(null=False, blank=False)
+
+    def __str__(self):
+        return f"{self.game} - {self.player} stats"

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,13 +9,22 @@ router.register(r'teams', views.TeamViewSet, basename='team')
 router.register(r'coaches', views.CoachViewSet, basename='coach')
 router.register(r'players', views.PlayerViewSet, basename='player')
 router.register(r'games', views.GameViewSet, basename='game')
+router.register(r'stats', views.StatsViewSet, basename='stats')
 
 teams_router = routers.NestedSimpleRouter(router, r'teams', lookup='team')
 teams_router.register(r'coach', views.CoachViewSet, basename='team-coach')
 teams_router.register(r'players', views.PlayerViewSet, basename='team-player')
 teams_router.register(r'games', views.GameViewSet, basename='team-game')
 
+games_router = routers.NestedSimpleRouter(router, r'games', lookup='game')
+games_router.register(r'stats', views.StatsViewSet, basename='game-stats')
+
+players_router = routers.NestedSimpleRouter(router, r'players', lookup='player')
+players_router.register(r'stats', views.StatsViewSet, basename='player-stats')
+
 urlpatterns = [
     path('', include(router.urls)),
     path('', include(teams_router.urls)),
+    path('', include(games_router.urls)),
+    path('', include(players_router.urls)),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,5 @@
-from api.models import Team, Coach, Player, Game
-from api.serializers import TeamSerializer, CoachSerializer, PlayerSerializer, GameSerializer
+from api.models import Team, Coach, Player, Game, Stats
+from api.serializers import TeamSerializer, CoachSerializer, PlayerSerializer, GameSerializer, StatsSerializer
 from rest_framework import viewsets
 from rest_framework import permissions
 
@@ -48,3 +48,21 @@ class GameViewSet(viewsets.ModelViewSet):
             return team_games
         else:
             return Game.objects.all()
+
+
+class StatsViewSet(viewsets.ModelViewSet):
+    queryset = Stats.objects.all()
+    serializer_class = StatsSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        game_id = self.kwargs.get('game_pk')
+        player_id = self.kwargs.get('player_pk')
+        if game_id:
+            game_stats = Stats.objects.filter(game_id=game_id).order_by('player__team')
+            return game_stats
+        elif player_id:
+            game_stats = Stats.objects.filter(player_id=player_id)
+            return game_stats
+        else:
+            return Stats.objects.all()


### PR DESCRIPTION
Create a stats feature, which enables adding stats of specific players in specific games. Include SerializerMethodFields to calculate fields, which can be calculated using model data. Add a link to boxscores (all of game's player stats) to games and add a link to all of specific players' stats in PlayerSerializer. Route urls and nested urls to aforementioned features. Resolves #40.