### PR TITLE
Coach Model and Serializer improvements

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -11,8 +11,8 @@ class Team(models.Model):
 
 class Coach(models.Model):
     name = models.CharField(max_length=100, blank=False, null=False)
-    date_of_birth = models.DateField(blank=True, null=True)
-    team = models.OneToOneField('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
+    date_of_birth = models.DateField(blank=False, null=False)
+    team = models.ForeignKey('Team', related_name='coach', on_delete=models.SET_NULL, null=True, blank=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Change OneToOneField to ForeignKey to allow a team to have no coach. Add a validator that ensures that a team doesn't have multiple coaches. Set date_of_birth as a required field, since coaches' age is validated.