### PR TITLE
Override istitle() with own validator

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -9,6 +9,7 @@ from api.validators import (
     validate_positive,
     validate_over_eighteen,
     validate_nonnegative,
+    validate_title_or_number_start,
 )
 from django.urls import reverse
 import datetime
@@ -245,8 +246,7 @@ class TeamSerializer(serializers.HyperlinkedModelSerializer):
         if not value.replace(' ', '').isalnum():
             raise serializers.ValidationError('Team name can contain only letters and numbers.')
 
-        if not value.istitle():
-            raise serializers.ValidationError('Team name should be capitalized.')
+        validate_title_or_number_start(value, 'Team name should be capitalized.')
 
         return value
 

--- a/api/validators.py
+++ b/api/validators.py
@@ -46,3 +46,15 @@ def validate_nonnegative(value, error_message):
         raise serializers.ValidationError(error_message)
 
     return value
+
+
+def validate_title_or_number_start(value, error_message):
+    words = value.split()
+
+    for word in words:
+        if word[0].islower():
+            raise serializers.ValidationError(error_message)
+
+        for char in word[1:]:
+            if char.isupper():
+                raise serializers.ValidationError(error_message)


### PR DESCRIPTION
Override istitle() with own validator to allow numbers in Team names. Resolves #54.