### PR TITLE
Dockerize the API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.pytest_cache/
+htmlcov/
+venv/
+.env
+.coverage
+db.sqlite3
+db.sqlite3-journal
+.idea/
+ownhoops/settings/development.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /usr/src/app
+
+RUN pip install --upgrade pip
+COPY requirements.txt /usr/src/app/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY ./entrypoint.sh /usr/src/app/entrypoint.sh
+
+COPY . /usr/src/app
+
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  ownhoops:
+    container_name: ownhoops_container
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - SECRET_KEY=${SECRET_KEY}
+      - PG_USER=${PG_USER}
+      - PG_PASSWORD=${PG_PASSWORD}
+      - PG_DB=${PG_DB}
+      - PG_HOST=db
+      - PG_PORT=${PG_PORT}
+      - DEBUG=${DEBUG}
+    depends_on:
+      - db
+  db:
+    container_name: db
+    image: postgres:12
+    environment:
+      - POSTGRES_USER=${PG_USER}
+      - POSTGRES_PASSWORD=${PG_PASSWORD}
+      - POSTGRES_DB=${PG_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata: {}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "Create migrations"
+python manage.py makemigrations api
+echo "============================="
+
+echo "Migrate"
+python manage.py migrate
+echo "============================="
+
+echo "Start server"
+python manage.py runserver --insecure 0.0.0.0:8000

--- a/ownhoops/settings/production.py
+++ b/ownhoops/settings/production.py
@@ -9,6 +9,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': os.environ.get('PG_DB'),
         'USER': os.environ.get('PG_USER'),
+        'PASSWORD': os.environ.get('PG_PASSWORD'),
         'HOST': os.environ.get('PG_HOST'),
         'PORT': os.environ.get('PG_PORT'),
     }


### PR DESCRIPTION
Add .dockerignore, Dockerfile, docker-compose.yml and entrypoint.sh to create a docker container for the project. Additionally, add missing PG_PASSWORD in production settings. Resolves #62.